### PR TITLE
Fix variable name in external token info

### DIFF
--- a/internal/info/external/external.go
+++ b/internal/info/external/external.go
@@ -21,8 +21,8 @@ type TokenInfo struct {
 	HoldersCount int
 }
 
-func GetTokenInfo(tokenID, tokentType string) (*TokenInfo, error) {
-	switch strings.ToLower(tokentType) {
+func GetTokenInfo(tokenID, tokenType string) (*TokenInfo, error) {
+	switch strings.ToLower(tokenType) {
 	case "erc20":
 		return GetTokenInfoForERC20(tokenID)
 	case "bep20":


### PR DESCRIPTION
## Summary
- correct `tokentType` parameter name to `tokenType`

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68449db747b8832c9014f40cc3712b12