### PR TITLE
Fix comment typo in SetConfig

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,7 +45,7 @@ type (
 // Default is a configuration instance.
 var Default = Config{} //nolint:gochecknoglobals // config must be global
 
-// SetConfig reads a config file and returs an initialized config instance.
+// SetConfig reads a config file and returns an initialized config instance.
 func SetConfig(confPath string) error {
 	confPath, err := filepath.Abs(confPath)
 	if err != nil {


### PR DESCRIPTION
## Summary
- correct 'returs' to 'returns' in SetConfig comment

## Testing
- `gofmt -w internal/config/config.go`

------
https://chatgpt.com/codex/tasks/task_e_68449f8cce64832cb8091650639ec70c