### PR TITLE
Add tests for BEP2 decimals validation

### DIFF
--- a/internal/info/decimals_test.go
+++ b/internal/info/decimals_test.go
@@ -1,0 +1,15 @@
+package info
+
+import "testing"
+
+func TestValidateAssetDecimalsAccordingType_BEP2InvalidDecimals(t *testing.T) {
+	if err := ValidateAssetDecimalsAccordingType("BEP2", 9); err == nil {
+		t.Fatal("expected error for BEP2 token with decimals != 8")
+	}
+}
+
+func TestValidateAssetDecimalsAccordingType_OtherTokenValid(t *testing.T) {
+	if err := ValidateAssetDecimalsAccordingType("ERC20", 18); err != nil {
+		t.Fatalf("unexpected error for non-BEP2 token: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add tests for `ValidateAssetDecimalsAccordingType` to ensure BEP2 tokens require 8 decimals

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68449f905410832cb5c6fbff363378fa